### PR TITLE
Remove api 3.2.5 support

### DIFF
--- a/plugin.yml
+++ b/plugin.yml
@@ -2,7 +2,7 @@
 name: MagicWE2
 main: xenialdan\MagicWE2\Loader
 version: 6.0.2
-api: [4.0.0+dev, 3.2.5+dev]
+api: [4.0.0+dev]
 load: STARTUP
 authors:
 - XenialDan


### PR DESCRIPTION
Since MagicWE2 makes use of the Language class which is the new name of BaseLang in 4.0.0, it cannot support 3.x anymore. This pr removes it from the plugin.yml file.

Directly related to #61